### PR TITLE
fix: correct repository clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Hatice was inspired by the architectural patterns demonstrated in [Symphony](htt
 
 ```bash
 # Clone
-git clone https://github.com/mertcanaltin/hatice.git
+git clone https://github.com/mksglu/hatice.git
 cd hatice
 
 # Install


### PR DESCRIPTION
Hi @mksglu,

While making edits with AI, I ended up updating the Git address to a non-existent one and didn’t catch it at the time. Sorry for the issue, and thanks for your understanding.