### PR TITLE
fix(github): use identifier as Issue.id so REST endpoints work

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -212,7 +212,7 @@ export class GitHubClient {
       : null;
 
     return {
-      id: node.id,
+      id: identifier,
       identifier,
       title: node.title,
       description: node.body,

--- a/test/github-client.test.ts
+++ b/test/github-client.test.ts
@@ -34,9 +34,9 @@ describe('GitHubClient', () => {
       const issues = await client.fetchIssues(['Todo', 'In Progress']);
 
       expect(issues).toHaveLength(2);
-      expect(issues[0].id).toBe('I_kwDOA1');
+      expect(issues[0].id).toBe('org/repo#42');
       expect(issues[0].title).toBe('Fix CI pipeline');
-      expect(issues[1].id).toBe('I_kwDOA2');
+      expect(issues[1].id).toBe('org/repo#43');
       expect(issues[1].title).toBe('Add feature X');
     });
 
@@ -204,6 +204,31 @@ describe('GitHubClient', () => {
           method: 'PATCH',
           body: JSON.stringify({ state: 'open' }),
         }),
+      );
+    });
+  });
+
+  describe('end-to-end: id returned from fetchIssues works with REST helpers', () => {
+    it('createComment hits the right REST URL when called with id from a fetched issue', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: () => Promise.resolve(issuesFixture),
+          text: () => Promise.resolve(JSON.stringify(issuesFixture)),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201, statusText: 'Created',
+          json: () => Promise.resolve({ id: 1 }),
+          text: () => Promise.resolve(JSON.stringify({ id: 1 })),
+        });
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const issues = await client.fetchIssues(['Todo']);
+      await client.createComment(issues[0].id, 'follow-up');
+
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        'https://api.github.com/repos/org/repo/issues/42/comments',
+        expect.objectContaining({ method: 'POST' }),
       );
     });
   });


### PR DESCRIPTION
## Summary

The GitHub adapter previously assigned the GraphQL global node ID
(e.g. `I_kwDORz9Qn8...`) to `Issue.id`. The orchestrator passes
`issue.id` to `createComment()` and `updateIssueState()`, which use the
REST API. `extractIssueNumber()` expected either `'owner/repo#N'`
format or a plain number — the node ID matched neither, producing
404 errors on every successful agent completion.

## Fix

Setting `id` to the same value as `identifier` (`'owner/repo#N'`) keeps
the key unique within a tracker and makes `extractIssueNumber()`
work without lookup state. Linear and GitLab adapters are
unaffected.

## Tests

Includes a new behavior-level test that fetches an issue and uses
its id with `createComment`, verifying the resulting REST URL ends
with the issue number rather than the node ID. Two existing
assertions that hard-coded the node ID literal were updated to
reflect the new identifier-form semantics — they were testing
implementation detail rather than observable behavior.
## Summary

The GitHub adapter previously assigned the GraphQL global node ID
(e.g. `I_kwDORz9Qn8...`) to `Issue.id`. The orchestrator passes
`issue.id` to `createComment()` and `updateIssueState()`, which use the
REST API. `extractIssueNumber()` expected either `'owner/repo#N'`
format or a plain number — the node ID matched neither, producing
404 errors on every successful agent completion.

## Fix

Setting `id` to the same value as `identifier` (`'owner/repo#N'`) keeps
the key unique within a tracker and makes `extractIssueNumber()`
work without lookup state. Linear and GitLab adapters are
unaffected.

## Tests

Includes a new behavior-level test that fetches an issue and uses
its id with `createComment`, verifying the resulting REST URL ends
with the issue number rather than the node ID. Two existing
assertions that hard-coded the node ID literal were updated to
reflect the new identifier-form semantics — they were testing
implementation detail rather than observable behavior.