### PR TITLE
feat(hooks): wire beforeRun/afterRun hooks and expose hatice_TITLE env var

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -211,10 +211,18 @@ export class Orchestrator extends EventEmitter<haticeEvents> {
     this.state.claim(issue.id);
 
     try {
-      const workspacePath = await this.workspace.ensureWorkspace(issue.identifier, issue.id);
+      const workspacePath = await this.workspace.ensureWorkspace(issue.identifier, issue.id, issue.title);
       const workflow = this.workflowStore.getCurrentWorkflow();
       if (!workflow) {
         throw new Error('No workflow loaded');
+      }
+
+      if (this.config.hooks.beforeRun) {
+        await this.workspace.runHook('beforeRun', this.config.hooks.beforeRun, workspacePath, {
+          issueId: issue.id,
+          identifier: issue.identifier,
+          title: issue.title ?? '',
+        });
       }
 
       const abortController = new AbortController();
@@ -248,6 +256,17 @@ export class Orchestrator extends EventEmitter<haticeEvents> {
 
       const promise = runner.run().then(async result => {
         clearInterval(stallTimer);
+        if (this.config.hooks.afterRun) {
+          try {
+            await this.workspace.runHook('afterRun', this.config.hooks.afterRun, workspacePath, {
+              issueId: issue.id,
+              identifier: issue.identifier,
+              title: issue.title ?? '',
+            });
+          } catch (e) {
+            this.log.warn({ err: e, issueId: issue.id }, 'afterRun hook failed, continuing');
+          }
+        }
         await this.handleWorkerExit(issue.id, result);
         return result;
       }).catch(e => {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -49,7 +49,7 @@ export class Workspace {
     return join(this.rootDir, sanitized);
   }
 
-  async ensureWorkspace(identifier: string, issueId: string): Promise<string> {
+  async ensureWorkspace(identifier: string, issueId: string, title?: string): Promise<string> {
     const workspacePath = this.getWorkspacePath(identifier);
     await this.validatePathSafety(workspacePath);
 
@@ -62,7 +62,7 @@ export class Workspace {
     }
 
     if (isNew && this.hooks.afterCreate) {
-      await this.runHook('afterCreate', this.hooks.afterCreate, workspacePath, { issueId, identifier });
+      await this.runHook('afterCreate', this.hooks.afterCreate, workspacePath, { issueId, identifier, title: title ?? '' });
     }
 
     if (!isNew) {
@@ -125,6 +125,7 @@ export class Workspace {
           hatice_ISSUE_ID: context.issueId ?? '',
           hatice_IDENTIFIER: context.identifier ?? '',
           hatice_WORKSPACE: workspacePath,
+          hatice_TITLE: context.title ?? '',
         },
         stdio: ['ignore', 'pipe', 'pipe'],
       });


### PR DESCRIPTION
Closes #10

## Summary

Two related fixes to the workspace hook system:

1. **Wire `beforeRun` / `afterRun` hooks.** They were declared in `HooksConfig` (`src/types.ts`) and parsed by the zod schema in `src/config.ts`, but `orchestrator.ts` never called them. Users who configured them in `WORKFLOW.md` got silent no-ops.
2. **Add `hatice_TITLE` env var** to the hook subprocess context, so hooks can route by title prefix (e.g. `[server]`, `[mobile]`) in multi-app monorepos.

## Changes

### `src/workspace.ts`
- `ensureWorkspace(identifier, issueId, title?)` now accepts an optional `title` and passes it through the `afterCreate` context.
- `runHook()` exports `hatice_TITLE: context.title ?? ''` alongside the existing `hatice_ISSUE_ID`, `hatice_IDENTIFIER`, `hatice_WORKSPACE` env vars.

### `src/orchestrator.ts`
- `dispatchIssue()` passes `issue.title` to `ensureWorkspace()`.
- Calls `beforeRun` before agent launch — fatal on failure, since the agent depends on hook side effects.
- Calls `afterRun` after agent completion — best-effort with `try/catch`, matching the existing `beforeRemove` pattern.

## Validation

- All 366 existing tests pass (`npx vitest run`).
- Typecheck clean (`npx tsc --noEmit`).
- Backward compatible: `title` is optional; existing callers and hook scripts that don't reference `hatice_TITLE` are unaffected.

## Use case that motivated this

Multi-app monorepo where the `afterCreate` hook needs to detect the target app from the issue title:

```bash
afterCreate: |
  case "$hatice_TITLE" in
    \[server\]*) APP="my-server" ;;
    \[mobile\]*) APP="my-mobile" ;;
  esac
  git worktree add "$hatice_WORKSPACE" -b "feat/$hatice_IDENTIFIER" HEAD
```

Without `hatice_TITLE` this routing is impossible.