### PR TITLE
fix(linear): scope updateIssueState workflow lookup by team

### DIFF
--- a/src/linear/client.ts
+++ b/src/linear/client.ts
@@ -219,13 +219,19 @@ export class LinearClient {
   }
 
   async updateIssueState(issueId: string, stateName: string): Promise<void> {
+    // Workflow states are per-team in Linear. Without scoping by team, this can
+    // return a state belonging to a different team and the issueUpdate mutation
+    // fails with: "Discrepancy between issue team and state, cycle or project".
     const statesData = await this.graphql<WorkflowStatesResult>(WORKFLOW_STATES_QUERY, {
-      filter: { name: { eq: stateName } },
+      filter: {
+        name: { eq: stateName },
+        team: { key: { eq: this.projectSlug } },
+      },
     });
 
     const stateNode = statesData.workflowStates.nodes[0];
     if (!stateNode) {
-      throw new TrackerError(`Workflow state "${stateName}" not found`);
+      throw new TrackerError(`Workflow state "${stateName}" not found in team "${this.projectSlug}"`);
     }
 
     await this.graphql(UPDATE_ISSUE_MUTATION, { issueId, stateId: stateNode.id });

--- a/test/linear-client.test.ts
+++ b/test/linear-client.test.ts
@@ -257,6 +257,30 @@ describe('LinearClient', () => {
       expect(secondBody.variables.issueId).toBe('issue-1');
       expect(secondBody.variables.stateId).toBe('state-done');
     });
+
+    it('scopes workflow state lookup to the configured team', async () => {
+      // Linear workflow states are per-team. Many teams have a state called "Done",
+      // each with a different UUID. Without team scoping, the API can return a
+      // foreign-team state ID and the issue update will fail with:
+      //   "Discrepancy between issue team and state, cycle or project"
+      const { fetchFn, calls } = mockFetch([
+        {
+          body: {
+            data: { workflowStates: { nodes: [{ id: 'state-done-proj', name: 'Done' }] } },
+          },
+        },
+        {
+          body: { data: { issueUpdate: { success: true } } },
+        },
+      ]);
+      globalThis.fetch = fetchFn;
+
+      const client = makeClient(); // makeClient passes 'PROJ' as the team key
+      await client.updateIssueState('issue-1', 'Done');
+
+      const firstBody = JSON.parse(calls[0].init.body as string);
+      expect(firstBody.variables.filter.team.key.eq).toBe('PROJ');
+    });
   });
 
   describe('fetchViewer', () => {


### PR DESCRIPTION
## Summary

`LinearClient.updateIssueState` looked up workflow states by name only,
then took `nodes[0]` from the result. Linear workflow states are
per-team, so in a workspace with multiple teams that share state names
(e.g. several teams each with a "Done" state), the query could return
a state belonging to a different team than the issue being updated.

The subsequent `issueUpdate` mutation then rejected the cross-team
state ID with:

> Linear GraphQL errors: Discrepancy between issue team and state, cycle or project

The orchestrator catches this as a warning and moves on, so the
completion comment is posted but the issue is silently left in its
pre-completion state (typically "In Progress").

## Fix

Add a `team.key.eq = projectSlug` filter to the workflow state
lookup so we always resolve the right team's state. Since hatice
already treats `projectSlug` as the team key (see `fetchIssues`),
this matches the existing single-team-per-workflow model.

Also tightens the not-found error message to include the team scope.

## Test plan

- [x] New test `scopes workflow state lookup to the configured team`
      asserts the team filter is included in the GraphQL request
- [x] Existing `updateIssueState` test still passes
- [x] Full suite: 367 tests passing
- [x] `tsc --noEmit` clean

## Repro before the fix

In a Linear workspace with multiple teams (e.g. `TEAMA`, `TEAMB`)
each having a state called "Done":

1. Configure WORKFLOW.md with `projectSlug: TEAMA`
2. Run hatice against an issue assigned to a TEAMA member
3. Agent completes successfully → orchestrator posts the completion
   comment, then attempts state transition to "Done"
4. If `nodes[0]` from `workflowStates(filter: { name: { eq: "Done" } })`
   returns TEAMB's "Done" state ID, Linear rejects the update with
   the discrepancy error and the issue remains in "In Progress"

After the fix, the team filter constrains the result so only TEAMA's
"Done" state is returned.