### PR TITLE
feat(claude): pass settingSources to Agent SDK

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -167,6 +167,7 @@ export class AgentRunner {
       permissionMode: claudeConfig.permissionMode,
       ...(claudeConfig.permissionMode === 'bypassPermissions' && { allowDangerouslySkipPermissions: true }),
       env: cleanEnv,
+      ...(claudeConfig.settingSources && { settingSources: claudeConfig.settingSources }),
       ...(claudeConfig.model && { model: claudeConfig.model }),
       ...(claudeConfig.allowedTools && { allowedTools: claudeConfig.allowedTools }),
       ...(claudeConfig.disallowedTools && { disallowedTools: claudeConfig.disallowedTools }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ const agentSchema = z.object({
 const claudeSchema = z.object({
   model: z.string().nullable().default(null),
   permissionMode: z.string().default('bypassPermissions'),
+  settingSources: z.array(z.enum(['user', 'project', 'local'])).nullable().default(['user', 'project', 'local']),
   turnTimeoutMs: z.number().default(3_600_000),
   stallTimeoutMs: z.number().default(300_000),
   allowedTools: z.array(z.string()).nullable().default(null),
@@ -83,6 +84,7 @@ const haticeConfigSchema = z.object({
   claude: claudeSchema.default({
     model: null,
     permissionMode: 'bypassPermissions',
+    settingSources: ['user', 'project', 'local'],
     turnTimeoutMs: 3_600_000,
     stallTimeoutMs: 300_000,
     allowedTools: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export interface AgentConfig {
 export interface ClaudeConfig {
   model: string | null;
   permissionMode: string;
+  settingSources: string[] | null;
   turnTimeoutMs: number;
   stallTimeoutMs: number;
   allowedTools: string[] | null;

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -45,6 +45,7 @@ function makeClaudeConfig(overrides: Partial<ClaudeConfig> = {}): ClaudeConfig {
   return {
     model: 'claude-sonnet-4-20250514',
     permissionMode: 'default',
+    settingSources: ['user', 'project', 'local'],
     turnTimeoutMs: 60_000,
     stallTimeoutMs: 30_000,
     allowedTools: null,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -116,6 +116,7 @@ describe('validateConfig', () => {
 
     // claude defaults
     expect(cfg.claude.permissionMode).toBe('bypassPermissions');
+    expect(cfg.claude.settingSources).toEqual(['user', 'project', 'local']);
     expect(cfg.claude.model).toBeNull();
     expect(cfg.claude.turnTimeoutMs).toBe(3_600_000);
     expect(cfg.claude.stallTimeoutMs).toBe(300_000);

--- a/test/integration/dispatch-cycle.test.ts
+++ b/test/integration/dispatch-cycle.test.ts
@@ -55,6 +55,7 @@ function createTestConfig(overrides: Partial<haticeConfig> = {}): haticeConfig {
     claude: {
       model: null,
       permissionMode: 'bypassPermissions',
+      settingSources: ['user', 'project', 'local'],
       turnTimeoutMs: 3_600_000,
       stallTimeoutMs: 300_000,
       allowedTools: null,

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -54,6 +54,7 @@ function createTestConfig(overrides: Partial<haticeConfig> = {}): haticeConfig {
     claude: {
       model: null,
       permissionMode: 'bypassPermissions',
+      settingSources: ['user', 'project', 'local'],
       turnTimeoutMs: 3_600_000,
       stallTimeoutMs: 300_000,
       allowedTools: null,

--- a/test/integration/wired-lifecycle.test.ts
+++ b/test/integration/wired-lifecycle.test.ts
@@ -61,6 +61,7 @@ function createTestConfig(overrides: Partial<haticeConfig> = {}): haticeConfig {
     claude: {
       model: null,
       permissionMode: 'bypassPermissions',
+      settingSources: ['user', 'project', 'local'],
       turnTimeoutMs: 3_600_000,
       stallTimeoutMs: 300_000,
       allowedTools: null,

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -107,6 +107,7 @@ function makeConfig(overrides: Partial<haticeConfig> = {}): haticeConfig {
     claude: {
       model: null,
       permissionMode: 'bypassPermissions',
+      settingSources: ['user', 'project', 'local'],
       turnTimeoutMs: 3_600_000,
       stallTimeoutMs: 300_000,
       allowedTools: null,


### PR DESCRIPTION
## Problem

Spawned agents currently receive no `settingSources` in their query options. This means they don't load CLAUDE.md files, project settings (.claude/settings.json), or user settings — so skills, hooks, and permission configs defined in the workspace are invisible to the agent.

## Fix

Add `settingSources` to `ClaudeConfig`. Default: `['user', 'project', 'local']` (all sources, matching Claude Code CLI behavior). Passed through to Agent SDK query options.

## Configuration

```yaml
# WORKFLOW.md frontmatter
claude:
  settingSources: ['project', 'local']  # skip user prefs
  # or null to disable (raw agent, no config inheritance)
```

## Changes

- `src/types.ts` — add `settingSources: string[] | null` to `ClaudeConfig`
- `src/config.ts` — Zod schema with `z.enum(['user', 'project', 'local'])` validation
- `src/agent-runner.ts` — pass through to SDK query options
- Tests updated (367 passing)