### PR TITLE
fix(security): default permissionMode to 'default' instead of 'bypassPermissions'

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ const agentSchema = z.object({
 
 const claudeSchema = z.object({
   model: z.string().nullable().default(null),
-  permissionMode: z.string().default('bypassPermissions'),
+  permissionMode: z.string().default('default'),
   turnTimeoutMs: z.number().default(3_600_000),
   stallTimeoutMs: z.number().default(300_000),
   allowedTools: z.array(z.string()).nullable().default(null),
@@ -82,7 +82,7 @@ const haticeConfigSchema = z.object({
   }),
   claude: claudeSchema.default({
     model: null,
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'default',
     turnTimeoutMs: 3_600_000,
     stallTimeoutMs: 300_000,
     allowedTools: null,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -115,7 +115,7 @@ describe('validateConfig', () => {
     expect(cfg.agent.maxConcurrentAgentsByState).toEqual({});
 
     // claude defaults
-    expect(cfg.claude.permissionMode).toBe('bypassPermissions');
+    expect(cfg.claude.permissionMode).toBe('default');
     expect(cfg.claude.model).toBeNull();
     expect(cfg.claude.turnTimeoutMs).toBe(3_600_000);
     expect(cfg.claude.stallTimeoutMs).toBe(300_000);


### PR DESCRIPTION
## Problem

The current default `permissionMode: 'bypassPermissions'` means every new workflow runs agents with **zero permission checks** unless the user explicitly opts into safety. This is invisible to security auditors — `allowDangerouslySkipPermissions: true` gets passed silently to the Agent SDK.

## Fix

Change the schema default from `'bypassPermissions'` to `'default'`. Agents will now prompt for permission on sensitive operations (file writes, shell commands, etc.), matching Claude Code CLI behavior.

## Migration

Existing workflows that rely on autonomous execution need one line added to their frontmatter:

```yaml
claude:
  permissionMode: bypassPermissions
```

## Breaking?

Yes — workflows without explicit `permissionMode` will now prompt. This is intentional: security defaults should be safe, with explicit opt-out for automation.

## Changes

- `src/config.ts` — schema default + haticeConfigSchema default object
- `test/config.test.ts` — updated default assertion
- Integration tests unchanged (they set `bypassPermissions` explicitly)
- 367 tests passing